### PR TITLE
Fix: Downgrade NumPy to 1.26.4 to resolve OpenCV import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,15 @@
 keyboard==0.13.5
 matplotlib==3.10.1
-numpy==2.2.5
+numpy==1.26.4
 opencv_contrib_python==4.8.1.78
 opencv_python==4.10.0.84
 opencv_python_headless==4.10.0.84
 psutil==5.9.6
 pyopencl==2023.1.4
 PyQt5==5.15.11
-PyQt5_sip==12.13.0
+PyQt5_sip==12.15.0
 pywin32==306
 Requests==2.32.3
 pyinstaller
+python-dotenv
+


### PR DESCRIPTION
Pull Request Description:

This pull request downgrades the numpy version from 2.2.5 to 1.26.4 in the requirements.txt file. The change addresses compatibility issues between OpenCV and NumPy 2.x, which caused the error:

!* ImportError: numpy.core.multiarray failed to import.

OpenCV currently requires a NumPy version < 2 for proper binary compatibility. Downgrading NumPy resolves the import error and allows the project to run successfully.